### PR TITLE
Update Makefile to have needed lib deps generated.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ IDIR=/usr/lib/jvm/java-8-oracle/include
 CFLAGS=-I${IDIR} -I$(IDIR)/linux
 SRCDIR=./ctp-api-linux64-20160628
 
-libctp.so: $(SRCDIR)/ctp_wrap.o 
-	cd $(SRCDIR); g++ -shared ctp_wrap.o -o $@
+libctp.so: /usr/lib/libthostmduserapi.so /usr/lib/libthosttraderapi.so $(SRCDIR)/ctp_wrap.o
+	cd $(SRCDIR); g++ -shared ctp_wrap.o -o libctp.so -Wl,--enable-new-dtags,-rpath,/usr/lib -L/usr/lib -lthostmduserapi -lthosttraderapi
 
 $(SRCDIR)/ctp_wrap.o: $(SRCDIR)/ctp_wrap.cxx
 	cd $(SRCDIR); g++ -c -fpic ctp_wrap.cxx -o ctp_wrap.o $(CFLAGS)


### PR DESCRIPTION
~/jctp/ readelf -d ctp-api-linux64-20160628/libctp.so

Dynamic section at offset 0x25adc0 contains 28 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libthostmduserapi.so]
 0x0000000000000001 (NEEDED)             Shared library: [libthosttraderapi.so]
 0x0000000000000001 (NEEDED)             Shared library: [libstdc++.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x000000000000001d (RUNPATH)            Library runpath: [/usr/lib]